### PR TITLE
Update docs how to create db connections using env var

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -26,7 +26,7 @@ or by creating a corresponding environment variable:
 
 .. code-block:: bash
 
-    AIRFLOW__CORE__SQL_ALCHEMY_CONN=my_conn_string
+    AIRFLOW_CONN_SQL_ALCHEMY_CONN=my_conn_string
 
 You can also derive the connection string at run time by appending ``_cmd`` to the key like this:
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
https://github.com/apache/incubator-airflow/blob/7765278479b81a73244ff44e47973bbc5bf9bcef/airflow/hooks/base_hook.py#L29 shows that the correct prefix of env var for creating a db connection is `AIRFLOW_CONN` as opposed to `AIRFLOW__CORE__`. So update the docs here. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
